### PR TITLE
add mocha

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 module.exports = {
     "env": {
         "es6": true,
+        "mocha": true,
         "node": true
     },
     "parserOptions": {


### PR DESCRIPTION
This change is needed if we want to add mocha tests to any repo. It take into account the mocha global variables and does not error on them, and other special syntax with the testing framework. I am using mocha tests in PR https://github.com/containership/cloud.api/pull/245 which is unable to pass the lint checks because of these errors.