### PR TITLE
fixes deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,7 @@ module.exports = {
         "node": true
     },
     "parserOptions": {
-        "ecmaVersion": 2017,
-        "ecmaFeatures": {
-            "experimentalObjectRestSpread": true
-        }
+        "ecmaVersion": 2018
     },
     "extends": [
         "eslint:recommended",


### PR DESCRIPTION
This fixes the following error that was showing up when working on the frontend api

`[ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in "@containership/eslint-config-containership.eslint.backend")`